### PR TITLE
version as var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Discovery Environment (CD). The jobs from CD are mostly prepared and executed
 using containers. Therefore all HTCondor cluster members except the master
 needs docker and docker-compose installed (roles: `docker`, `docker-compose`).
 
+## vars needed
+Change the needed var in `group_vars/all.yml`, especially:
+* `condor_domain`: The domain-name the HTCondor-cluster is running in.
+* `common__condor_version`: This role-var should be set *globally*. It
+  determines the condor-version that will be installed (for all supported
+  linux distributions).
+
 ### de-condor-launcher
 
 This program accepts job requests from DE and submits it to the HTCondor

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,5 +1,4 @@
 ---
-
 environment_name: qa
 timezone: Europe/Vienna
 docker:
@@ -12,15 +11,20 @@ docker:
 #     user: "someuser"
 #     password: "notreal"
 #     test_image: "registry.example.org/image:latest"
+
+tmp_condor_domain: "cyverse.at"
+tmp_read_write: >-
+  ["*.{{ tmp_condor_domain }},127.0.0.1
+  {%- for host in groups['all'] -%}
+  ,{{ hostvars[host]['ansible_default_ipv4']['address'] }}
+  {%- endfor %}"]
 condor:
   admin: "grid@tugraz.at"
-  uid_domain: "cyverse.at"
-  filesystem_domain: "cyverse.at"
+  uid_domain: "{{ tmp_condor_domain }}"
+  filesystem_domain: "{{ tmp_condor_domain }}"
   collector_name: "example-collector"
-  allow_read: ["*.cyverse.at", "127.0.0.1,134.209.82.111/24,134.209.82.110/24,174.138.2.245/24,134.209.82.109/24"]
-  allow_write: ["*.cyverse.at", "127.0.0.1,134.209.82.111/24,134.209.82.110/24,174.138.2.245/24,134.209.82.109/24"]
-  # allow_read: ["*.example.org", "1.2.3.0/24"]
-  # allow_write: ["*.example.org", "1.2.3.0/24"]
+  allow_write: "{{ tmp_read_write }}"
+  allow_read: "{{ tmp_read_write }}"
   exec_dir: "/var/lib/condor/execute/jobs"
   # password: "notreal"
   password: "notreal:seemstobemuchtoshort.sothisoneisalongerversionofapassword"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -13,21 +13,26 @@ docker:
 #     password: "notreal"
 #     test_image: "registry.example.org/image:latest"
 
-tmp_condor_domain: "cyverse.at"
+condor_domain: "domain.com"
+common__condor_version: 10
+allow_hosts: ""
+
 tmp_read_write: >-
-  ["*.{{ tmp_condor_domain }},127.0.0.1
+  ["*.{{ condor_domain }},127.0.0.1
   {%- for host in groups['all'] -%}
   ,{{ hostvars[host]['ansible_default_ipv4']['address'] }}
-  {%- endfor %}"]
+  {%- endfor %}
+  {%- if allow_hosts|length -%}
+  ,{{ allow_hosts }}
+  {%- endif %}"]
 condor:
-  admin: "grid@tugraz.at"
-  uid_domain: "{{ tmp_condor_domain }}"
-  filesystem_domain: "{{ tmp_condor_domain }}"
+  admin: "grid@{{ condor_domain }}"
+  uid_domain: "{{ condor_domain }}"
+  filesystem_domain: "{{ condor_domain }}"
   collector_name: "example-collector"
   allow_write: "{{ tmp_read_write }}"
   allow_read: "{{ tmp_read_write }}"
   exec_dir: "/var/lib/condor/execute/jobs"
-  # password: "notreal"
   password: "notreal:seemstobemuchtoshort.sothisoneisalongerversionofapassword"
 
 use_overlay: ''

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,5 @@
 ---
+
 environment_name: qa
 timezone: Europe/Vienna
 docker:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
-common__redhat_key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-23.0-Key"
+# HTCondor version: 9,10 or 23
+common__condor_version: 10
+common__redhat_key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-{{ common__condor_version }}.0-Key"
 common__redhat_rpm: "https://research.cs.wisc.edu/htcondor/repo/current/htcondor-release-current.el9.noarch.rpm"
-common__debian_key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key"
+common__debian_key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-{{ common__condor_version }}.x-Key"

--- a/roles/common/tasks/Debian.yml
+++ b/roles/common/tasks/Debian.yml
@@ -19,7 +19,7 @@
     - name: Add repo
       ansible.builtin.apt_repository:
         repo: >
-          deb http://research.cs.wisc.edu/htcondor/repo/debian/10.x
+          deb http://research.cs.wisc.edu/htcondor/repo/debian/{{ common__condor_version }}.x
           {{ ansible_distribution_release }} main
         filename: htcondor
         state: present


### PR DESCRIPTION
changed the `allow_{read,write}` from sting to calculation
created a var `common__condor_version` to choose the condor-version (9,10 or 23)